### PR TITLE
Use Task.Run in C# code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ my_thread.join();
 
 ```csharp
 // C#
-var result = await Task<string[]>.Factory.StartNew(() => {
+var result = await Task.Run(() => {
   // ... lots and lots of work ...
 });
 ```


### PR DESCRIPTION
For this basic use case, it's usually preferred to use `Task.Run` rather than `Task.Factory.StartNew`

Ref:
https://blogs.msdn.microsoft.com/pfxteam/2011/10/24/task-run-vs-task-factory-startnew/
https://docs.microsoft.com/en-us/dotnet/standard/parallel-programming/task-based-asynchronous-programming